### PR TITLE
Updated go-ibft version and added additional logs.

### DIFF
--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -102,7 +102,7 @@ func DefaultConfig() *Config {
 			MaxSlots:           4096,
 			MaxAccountEnqueued: 128,
 		},
-		LogLevel:    "INFO",
+		LogLevel:    "DEBUG",
 		RestoreFile: "",
 		BlockTime:   DefaultBlockTime,
 		Headers: &Headers{

--- a/consensus/ibft/consensus.go
+++ b/consensus/ibft/consensus.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/0xPolygon/go-ibft/core"
+	"github.com/Route3/go-ibft/core"
 )
 
 // IBFTConsensus is a convenience wrapper for the go-ibft package

--- a/consensus/ibft/consensus_backend.go
+++ b/consensus/ibft/consensus_backend.go
@@ -6,12 +6,12 @@ import (
 	"math"
 	"time"
 
-	"github.com/0xPolygon/go-ibft/messages"
 	"github.com/0xPolygon/polygon-edge/consensus"
 	"github.com/0xPolygon/polygon-edge/consensus/ibft/signer"
 	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/Route3/go-ibft/messages"
 )
 
 func (i *backendIBFT) BuildProposal(blockNumber uint64) []byte {

--- a/consensus/ibft/ibft.go
+++ b/consensus/ibft/ibft.go
@@ -264,6 +264,7 @@ func (i *backendIBFT) startConsensus() {
 
 		for {
 			if ev := <-eventCh; ev.Source == "syncer" {
+				i.logger.Debug("received syncer event", "event height", ev.NewChain[0].Number, "current height", i.blockchain.Header().Number)
 				if ev.NewChain[0].Number < i.blockchain.Header().Number {
 					// The blockchain notification system can eventually deliver
 					// stale block notifications. These should be ignored
@@ -309,14 +310,20 @@ func (i *backendIBFT) startConsensus() {
 
 		select {
 		case <-syncerBlockCh:
+			i.logger.Debug("channel: syncerBlockCh")
 			if isValidator {
+				i.logger.Debug("canceling sequence", "sequence", pending)
 				i.consensus.stopSequence()
 				i.logger.Info("canceled sequence", "sequence", pending)
 			}
 		case <-sequenceCh:
+			i.logger.Debug("channel: sequenceCh")
 		case <-i.closeCh:
+			i.logger.Debug("channel: closeCh")
 			if isValidator {
+				i.logger.Debug("canceling sequence", "sequence", pending)
 				i.consensus.stopSequence()
+				i.logger.Info("canceled sequence", "sequence", pending)
 			}
 
 			return

--- a/consensus/ibft/messages.go
+++ b/consensus/ibft/messages.go
@@ -3,8 +3,8 @@ package ibft
 import (
 	"google.golang.org/protobuf/proto"
 
-	protoIBFT "github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/0xPolygon/polygon-edge/types"
+	protoIBFT "github.com/Route3/go-ibft/messages/proto"
 )
 
 func (i *backendIBFT) signMessage(msg *protoIBFT.Message) *protoIBFT.Message {

--- a/consensus/ibft/transport.go
+++ b/consensus/ibft/transport.go
@@ -1,9 +1,9 @@
 package ibft
 
 import (
-	"github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/0xPolygon/polygon-edge/network"
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/Route3/go-ibft/messages/proto"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 

--- a/consensus/ibft/verifier.go
+++ b/consensus/ibft/verifier.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/hex"
 
-	"github.com/0xPolygon/go-ibft/messages"
-	protoIBFT "github.com/0xPolygon/go-ibft/messages/proto"
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/Route3/go-ibft/messages"
+	protoIBFT "github.com/Route3/go-ibft/messages/proto"
 )
 
 // Verifier impl for go-ibft

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,12 @@ module github.com/0xPolygon/polygon-edge
 go 1.18
 
 require (
+	cloud.google.com/go/secretmanager v1.8.0
+	github.com/Route3/go-ibft v0.0.0-20230915132655-8d4c4c12f3cc
+	github.com/armon/go-metrics v0.4.1
+	github.com/aws/aws-sdk-go v1.44.61
 	github.com/btcsuite/btcd v0.22.1
-	github.com/containerd/cgroups v1.0.4 // indirect
-	github.com/elastic/gosigar v0.14.2 // indirect
+	github.com/coinbase/kryptology v1.8.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
@@ -18,50 +21,23 @@ require (
 	github.com/libp2p/go-libp2p v0.22.0
 	github.com/libp2p/go-libp2p-kbucket v0.5.0
 	github.com/libp2p/go-libp2p-pubsub v0.8.1
-	github.com/miekg/dns v1.1.50 // indirect
-	github.com/multiformats/go-base32 v0.0.4 // indirect
 	github.com/multiformats/go-multiaddr v0.7.0
-	github.com/multiformats/go-multihash v0.2.1 // indirect
-	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/prometheus/client_golang v1.13.1
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+	github.com/umbracle/ethgo v0.1.4-0.20221117101647-b81ef2f07953
 	github.com/umbracle/fastrlp v0.0.0-20220527094140-59d5dd30e722
 	github.com/umbracle/go-eth-bn256 v0.0.0-20190607160430-b36caf4e0f6b
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
+	google.golang.org/genproto v0.0.0-20221010155953-15ba04fc1c0e
 	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.28.1
+	gopkg.in/DataDog/dd-trace-go.v1 v1.43.1
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
-)
-
-require (
-	cloud.google.com/go/secretmanager v1.8.0
-	github.com/armon/go-metrics v0.4.1
-	github.com/aws/aws-sdk-go v1.44.61
-	github.com/benbjohnson/clock v1.3.0 // indirect
-	github.com/coinbase/kryptology v1.8.0
-	github.com/fatih/color v1.13.0 // indirect
-	github.com/fsnotify/fsnotify v1.5.4 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
-	github.com/ipfs/go-cid v0.2.0 // indirect
-	github.com/klauspost/compress v1.15.5 // indirect
-	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/umbracle/ethgo v0.1.4-0.20221117101647-b81ef2f07953
-	github.com/valyala/fastjson v1.6.3 // indirect
-	go.uber.org/zap v1.22.0 // indirect
-	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
-	golang.org/x/tools v0.1.12 // indirect
-	google.golang.org/genproto v0.0.0-20221010155953-15ba04fc1c0e
 	gopkg.in/yaml.v3 v3.0.1
-	lukechampine.com/blake3 v1.1.7 // indirect
 )
-
-require github.com/0xPolygon/go-ibft v0.0.0-20220810095021-e43142f8d267
-
-require gopkg.in/DataDog/dd-trace-go.v1 v1.43.1
 
 require (
 	cloud.google.com/go/compute v1.10.0 // indirect
@@ -75,6 +51,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
@@ -83,6 +60,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cheekybits/genny v1.0.0 // indirect
 	github.com/consensys/gnark-crypto v0.5.3 // indirect
+	github.com/containerd/cgroups v1.0.4 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
@@ -90,9 +68,13 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/elastic/gosigar v0.14.2 // indirect
+	github.com/fatih/color v1.13.0 // indirect
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
+	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -118,6 +100,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/ipfs/go-cid v0.2.0 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
@@ -125,6 +108,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/klauspost/compress v1.15.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.1.0 // indirect
 	github.com/koron/go-ssdp v0.0.3 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
@@ -144,26 +128,32 @@ require (
 	github.com/marten-seemann/qtls-go1-18 v0.1.2 // indirect
 	github.com/marten-seemann/qtls-go1-19 v0.1.0 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/miekg/dns v1.1.50 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
+	github.com/multiformats/go-base32 v0.0.4 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
 	github.com/multiformats/go-multicodec v0.5.0 // indirect
+	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-multistream v0.3.3 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/opencontainers/runtime-spec v1.0.2 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
@@ -183,22 +173,28 @@ require (
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.37.0 // indirect
+	github.com/valyala/fastjson v1.6.3 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
+	go.uber.org/goleak v1.2.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
+	go.uber.org/zap v1.22.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458 // indirect
 	golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1 // indirect
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0 // indirect
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 	golang.org/x/text v0.3.8 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
+	golang.org/x/tools v0.1.12 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.99.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	inet.af/netaddr v0.0.0-20220617031823-097006376321 // indirect
+	lukechampine.com/blake3 v1.1.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 filippo.io/edwards25519 v1.0.0-rc.1 h1:m0VOOB23frXZvAOK44usCgLWvtsxIoMCTBGJZlpmGfU=
 filippo.io/edwards25519 v1.0.0-rc.1/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/0xPolygon/go-ibft v0.0.0-20220810095021-e43142f8d267 h1:+mFLx9IKW16fOcTKjZjkom3TGnihOuPwYAz2c6+UUWQ=
-github.com/0xPolygon/go-ibft v0.0.0-20220810095021-e43142f8d267/go.mod h1:QPrugDXgsCFy2FeCJ0YokPrnyi1GoLhDj/PLO1dSoNY=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -67,6 +65,8 @@ github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpz
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
+github.com/Route3/go-ibft v0.0.0-20230915132655-8d4c4c12f3cc h1:fmuEcNvjWl7I6Sgj/JrFamZDT1EtLG+zRgRJG/G5BVw=
+github.com/Route3/go-ibft v0.0.0-20230915132655-8d4c4c12f3cc/go.mod h1:k8xnJq3iMA1LsxVAhooAMDvpqaLUH9m9Ka8/SPrjevU=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -723,7 +723,8 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
-go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -249,7 +249,16 @@ func (s *syncer) bulkSyncWithPeer(peerID peer.ID, newBlockCallback func(*types.B
 			shouldTerminate = newBlockCallback(block)
 
 			lastReceivedNumber = block.Number()
+			s.logger.Debug("bulk syncer block written",
+				"local_latest", localLatest,
+				"last_received", lastReceivedNumber,
+				"should_terminate", shouldTerminate)
 		case <-time.After(s.blockTimeout):
+			s.logger.Debug("bulk syncer block timeout",
+				"timeout", s.blockTimeout,
+				"local_latest", localLatest,
+				"last_received", lastReceivedNumber,
+				"should_terminate", shouldTerminate)
 			return lastReceivedNumber, shouldTerminate, errTimeout
 		}
 	}


### PR DESCRIPTION
# Description

Let's imagine the following scenario: 

Under normal circumstances, when a quorum amount of nodes detects significant delay in producing a block, they agree the current round should be canceled. And it is. After timeout of **10s** everyone exchanged their RCC (Round Change Certificate) messages and the round is bumped. 

But, for the proposer the round just started, and timeout is far. In the exact same moment ****proposer manages to produce a block and receive necessary amount of round change requests. This block is written into the storage and just before the proposer could mark the sequence as completed it processes in parallel the RCC and **bumps the round** like the rest, **not canceling the sequence**.

Because the block was written but the round is bumped, previous proposer is expecting a block of height 17208345 on current height. Resulting in `sequence not correct` logs. 

What can also be observed is `nonce too low` errors in the logs. These happen because the block is written already, expected nonces are bumped, and the expected ones are rejected.

This completely halts consensus for the previousl proposer node.

Subsequently, two distinct groups of node states are observed:

- Those that both committed the block and concurrently transitioned to a new round (comprising the majority of nodes). It only took around a second for nodes to confirm the block.
- Those that received the block from other nodes via the block syncing mechanism before committing it themselves. This led to a canceled sequence, a bumped height, and these nodes were left isolated at that height. This can be confirmed by not finding the `block committed` log.
-
# Reproducibility

1. Quorum amount of nodes at height N.
2. Just before the timeout, the proposer for the 0th round is entering the Fin state (e.g. writing the block after receiving ≥ quorum number of commit messages from other nodes).
3. Issue round timeout from other nodes.
4. After writing the block, but before marking the sequence as done, acknowledge the RCC and cancel the round.
5. Observe that quorum amount of other nodes did the same

Expected timeline should be the following: [Link to Excalidraw](https://excalidraw.com/#json=T4tUb0wlgxsi481MSoa5y,kGAkFnORQlFOnIhJTdfYnQ)

# Remediation

To alleviate the problem, fix should include few lines of code that addresses the situation where fin state can be interrupted after committing the block. 

Namely in go-ibft [fin state](https://github.com/0xPolygon/go-ibft/blob/e43142f8d2671dfd3858ca1b32823c5c39174984/core/ibft.go#L516):

```golang
case fin:
			i.runFin()
			// Round timeout happens before this point
			i.signalRoundDone(ctx) // Offending function call

			return
		}
```

Signal round done function is comprised of the following select statement:

```golang
func (i *IBFT) signalRoundDone(ctx context.Context) {
	select {
	case i.roundDone <- struct{}{}:
	case <-ctx.Done(): // Takes precedence over round done when ctx is done due to timeout
	}
}
```

In the fin state, the `signalRoundDone` function should not care about context cancellation and should always proceed to notify `RunSequence` function of sequence completeness.

For the two scenarios that we discussed earlier, for those who committed they will enter next height as they should, and for those who received the block trough `syncer`, they will naturally cancel the current sequence in favor of the new one.

Kudos to @trimixlover for remediating the issue.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
